### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/more_printing.rs
+++ b/src/more_printing.rs
@@ -15,7 +15,7 @@ pub fn show() {
 
     // system {variable: padding alignment minimum.maximum}
     let letter = "a";
-    println!("{:あ^5.}", letter);
+    println!("{:あ^5}", letter);
 
     // example
     // print beautiful table


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.